### PR TITLE
Support reading clinical data (FHIR) from the HealthKit store in iOS 12

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -185,6 +185,13 @@ static NSString *const HKPluginKeyUUID = @"UUID";
         return type;
     }
 
+    if (@available(iOS 12.0, *)) {
+      type = [HKObjectType clinicalTypeForIdentifier:elem];
+      if (type != nil) {
+        return type;
+      }
+    }
+
     // @TODO | The fall through here is inefficient.
     // @TODO | It needs to be refactored so the same HK method isnt called twice
     return [HealthKit getHKSampleType:elem];

--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -245,6 +245,13 @@ static NSString *const HKPluginKeyUUID = @"UUID";
         }
     }
 
+    if (@available(iOS 12.0, *)) {
+      type = [HKObjectType clinicalTypeForIdentifier:elem];
+      if (type != nil) {
+        return type;
+      }
+    }
+
     // leave this here for if/when apple adds other sample types
     return type;
 

--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -1366,6 +1366,33 @@ static NSString *const HKPluginKeyUUID = @"UUID";
                                                                               HKWorkout *wsample = (HKWorkout *) sample;
                                                                               [entry setValue:@(wsample.duration) forKey:@"duration"];
 
+                                                                          } else {
+
+                                                                            if (@available(iOS 12.0, *)) {
+                                                                            
+                                                                                if ([sample isKindOfClass:[HKClinicalRecord class]]) {
+                                                                                    HKClinicalRecord *clinicalRecord = (HKClinicalRecord *) sample;
+                                                                                    NSError *err = nil;
+                                                                                    NSDictionary *fhirData = [NSJSONSerialization JSONObjectWithData:clinicalRecord.FHIRResource.data options:NSJSONReadingMutableContainers error:&err];
+                                                                                    
+                                                                                    if (err != nil) {
+                                                                                        dispatch_sync(dispatch_get_main_queue(), ^{
+                                                                                            [HealthKit triggerErrorCallbackWithMessage:err.localizedDescription command:command delegate:bSelf.commandDelegate];
+                                                                                        });
+                                                                                        return;
+                                                                                    } else {
+                                                                                        NSDictionary *fhirResource = @{
+                                                                                                        @"identifier": clinicalRecord.FHIRResource.identifier,
+                                                                                                        @"sourceURL": clinicalRecord.FHIRResource.sourceURL.absoluteString,
+                                                                                                        @"displayName": clinicalRecord.displayName,
+                                                                                                        @"data": fhirData
+                                                                                                    };
+                                                                                        entry[@"FHIRResource"] = fhirResource;
+                                                                                    }
+                                                                                }
+                                                                            
+                                                                            }
+
                                                                           }
 
                                                                           [finalResults addObject:entry];


### PR DESCRIPTION
This PR has 3 commits that add support for reading Fast Healthcare Interoperability Resources (FHIR) from the HealthKit store.  These clinical records will be available in iOS 12 and the appropriate checks for the iOS version have been made in the code.  [Here is a brief article by Apple on accessing health records](https://developer.apple.com/documentation/healthkit/health_and_fitness_samples/accessing_health_records?language=objc)

Commit 21db105 adds support for authorizing reading of the clinical record types shown below - 

- HKClinicalTypeIdentifierAllergyRecord
- HKClinicalTypeIdentifierConditionRecord
- HKClinicalTypeIdentifierImmunizationRecord
- HKClinicalTypeIdentifierLabResultRecord
- HKClinicalTypeIdentifierMedicationRecord
- HKClinicalTypeIdentifierProcedureRecord
- HKClinicalTypeIdentifierVitalSignRecord

Commit ae0bcdd and 9492fac add support querying health records for any of the clinical record types shown above.

Thanks for this great plugin Eddy, I've been a fan of yours for years and greatly benefited from your projects 🍻  