### PR TITLE
Separate the implementation for clinical records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * `queryCorrelationType`
 * `deleteSamples`
 
-Read below about CLINICAL_READ_PERMISSION to use these
+Read below about `CLINICAL_READ_PERMISSION` to use these
 * `queryClinicalSampleType`
 * `queryForClinicalRecordsFromSource`
 * `queryForClinicalRecordsWithFHIRResourceType`
@@ -60,7 +60,9 @@ cordova plugin add com.telerik.plugins.healthkit --variable HEALTH_READ_PERMISSI
 
 If you would like to read clinical record data from the HealthKit store you will need to provide an extra variable during the plugin install.  The `CLINICAL_READ_PERMISSION` can be set to include the ability to read FHIR resources.  The value that is set here will be used in the `NSHealthClinicalHealthRecordsShareUsageDescription` key of your app's `info.plist` file.  It will be shown when your app asks for clinical record data from HealthKit.  Do not include the `CLINICAL_READ_PERMISSION` variable unless you really need access to the clinical record data otherwise Apple may reject your app.
 
-Here is an example - 
+You will also need to manually check the `Health Records` capability for your app in Xcode under the HealthKit capability.
+
+Here is an install example with `CLINICAL_READ_PERMISSION` - 
 ```bash
 cordova plugin add com.telerik.plugins.healthkit --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access' --variable CLINICAL_READ_PERMISSION='App needs read access' --save
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@
 * `queryCorrelationType`
 * `deleteSamples`
 
+Read below about CLINICAL_READ_PERMISSION to use these
+* `queryClinicalSampleType`
+* `queryForClinicalRecordsFromSource`
+* `queryForClinicalRecordsWithFHIRResourceType`
+
 ### Resources
 
 * The official Apple documentation for [HealthKit can be found here](https://developer.apple.com/library/ios/documentation/HealthKit/Reference/HealthKit_Framework/index.html#//apple_ref/doc/uid/TP40014707).
@@ -52,6 +57,14 @@ Using the Cordova CLI?
 cordova plugin add com.telerik.plugins.healthkit --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access'
 ```
 `HEALTH_READ_PERMISSION` and `HEALTH_WRITE_PERMISSION` are shown when your app asks for access to data in HealthKit.
+
+If you would like to read clinical record data from the HealthKit store you will need to provide an extra variable during the plugin install.  The `CLINICAL_READ_PERMISSION` can be set to include the ability to read FHIR resources.  The value that is set here will be used in the `NSHealthClinicalHealthRecordsShareUsageDescription` key of your app's `info.plist` file.  It will be shown when your app asks for clinical record data from HealthKit.  Do not include the `CLINICAL_READ_PERMISSION` variable unless you really need access to the clinical record data otherwise Apple may reject your app.
+
+Here is an example - 
+```bash
+cordova plugin add com.telerik.plugins.healthkit --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access' --variable CLINICAL_READ_PERMISSION='App needs read access' --save
+```
+
 
 #### Using PhoneGap Build?
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -124,6 +124,16 @@
       'HKQuantityTypeIdentifierDietaryFatTotal'
     ];
 
+    // or any of these HKClinicalType for readTypes 
+    // use these to access health records (read only)
+    // HKClinicalTypeIdentifierAllergyRecord
+    // HKClinicalTypeIdentifierConditionRecord
+    // HKClinicalTypeIdentifierImmunizationRecord
+    // HKClinicalTypeIdentifierLabResultRecord
+    // HKClinicalTypeIdentifierMedicationRecord
+    // HKClinicalTypeIdentifierProcedureRecord
+    // HKClinicalTypeIdentifierVitalSignRecord
+
     window.plugins.healthkit.requestAuthorization(
         {
           readTypes: supportedTypes,
@@ -280,6 +290,77 @@
         },
         callback,
         callback
+    );
+  }
+
+  // used to query a specified clinical sample type
+  function queryClinicalSampleType() {
+    window.plugins.healthkit.queryClinicalSampleType(
+      {
+        'startDate': new Date(new Date().getTime() - 365 * 24 * 60 * 60 * 1000), // 365 days ago
+        'endDate': new Date(), // now
+        'sampleType': 'HKClinicalTypeIdentifierAllergyRecord',
+        // or any of these other HKClinicalType
+        // HKClinicalTypeIdentifierConditionRecord
+        // HKClinicalTypeIdentifierImmunizationRecord
+        // HKClinicalTypeIdentifierLabResultRecord
+        // HKClinicalTypeIdentifierMedicationRecord
+        // HKClinicalTypeIdentifierProcedureRecord
+        // HKClinicalTypeIdentifierVitalSignRecord
+      },
+      callback,
+      callback
+    );
+  }
+
+  // this is used to search for a specific FHIR resource type
+  // it uses predicateForClinicalRecordsWithFHIRResourceType (https://developer.apple.com/documentation/healthkit/hkquery/2999414-predicateforclinicalrecordswithf?language=objc)
+  // In most cases, there’s a one-to-one correspondance between the clinical record types and the FHIR resource types; 
+  // therefore, most queries already return samples from a single FHIR resource type. 
+  // However, queries for the HKClinicalTypeIdentifierMedicationRecord type can return records from the 
+  // HKFHIRResourceTypeMedicationOrder, HKFHIRResourceTypeMedicationDispense, and HKFHIRResourceTypeMedicationStatement FHIR resource types. 
+  // You can use this predicate to limit your query to one of these FHIR types.
+  function queryForClinicalRecordsWithFHIRResourceType() {
+    window.plugins.healthkit.queryForClinicalRecordsWithFHIRResourceType(
+      {
+        fhirResourceType: 'HKFHIRResourceTypeCondition',
+        sampleType: 'HKClinicalTypeIdentifierConditionRecord'
+        // or any of these other HKFHIRResourceType
+        // HKFHIRResourceTypeAllergyIntolerance',
+        // HKFHIRResourceTypeImmunization
+        // HKFHIRResourceTypeMedicationDispense
+        // HKFHIRResourceTypeMedicationOrder
+        // HKFHIRResourceTypeMedicationStatement
+        // HKFHIRResourceTypeObservation
+        // HKFHIRResourceTypeProcedure
+
+        // or any of these other HKClinicalType
+        // HKClinicalTypeIdentifierImmunizationRecord
+        // HKClinicalTypeIdentifierLabResultRecord
+        // HKClinicalTypeIdentifierMedicationRecord
+        // HKClinicalTypeIdentifierProcedureRecord
+        // HKClinicalTypeIdentifierVitalSignRecord
+      },
+      callback,
+      callback
+    );
+  }
+
+  // this is used to find a particular FHIR record
+  // it uses predicateForClinicalRecordsFromSource (https://developer.apple.com/documentation/healthkit/hkquery/2999413-predicateforclinicalrecordsfroms?language=objc)
+  function queryForClinicalRecordsFromSource() {
+    window.plugins.healthkit.queryForClinicalRecordsFromSource(
+      {
+        fhirResourceType: 'HKFHIRResourceTypeCondition',
+        sampleType: 'HKClinicalTypeIdentifierConditionRecord',
+        identifier: '42467', // the identifier of the FHIR resource
+        source: { // the provenance of this FHIR record
+          name: 'Sample Location C',
+          bundleIdentifier: 'com.apple.public.health.clinical.7D9AED77-AD3F-7801-5A65-59F537187C7D'
+        }
+      },
+      callback,
+      callback
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "com.telerik.plugins.healthkit",
+  "version": "0.5.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "base64-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
+      "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg=",
+      "dev": true
+    },
+    "big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "dev": true
+    },
+    "bplist-creator": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+      "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+      "dev": true,
+      "requires": {
+        "stream-buffers": "~2.2.0"
+      }
+    },
+    "bplist-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+      "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.7"
+      }
+    },
+    "pegjs": {
+      "version": "0.10.0",
+      "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+      "dev": true
+    },
+    "plist": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
+      "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.1.2",
+        "xmlbuilder": "8.2.2",
+        "xmldom": "0.1.x"
+      }
+    },
+    "simple-plist": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
+      "integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
+      "dev": true,
+      "requires": {
+        "bplist-creator": "0.0.7",
+        "bplist-parser": "0.1.1",
+        "plist": "2.0.1"
+      }
+    },
+    "stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+      "dev": true
+    },
+    "xcode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xcode/-/xcode-1.0.0.tgz",
+      "integrity": "sha1-4fWxRDJF3tOMGAeW3xoQ/e2ghOw=",
+      "dev": true,
+      "requires": {
+        "pegjs": "^0.10.0",
+        "simple-plist": "^0.2.1",
+        "uuid": "3.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,20 +7,17 @@
     "base64-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
-      "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg=",
-      "dev": true
+      "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
     },
     "big-integer": {
-      "version": "1.6.36",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
-      "dev": true
+      "version": "1.6.40",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.40.tgz",
+      "integrity": "sha512-CjhtJp0BViLzP1ZkEnoywjgtFQXS2pomKjAJtIISTCnuHILkLcAXLdFLG/nxsHc4s9kJfc+82Xpg8WNyhfACzQ=="
     },
     "bplist-creator": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
       "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
-      "dev": true,
       "requires": {
         "stream-buffers": "~2.2.0"
       }
@@ -29,7 +26,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
       "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
-      "dev": true,
       "requires": {
         "big-integer": "^1.6.7"
       }
@@ -37,14 +33,12 @@
     "pegjs": {
       "version": "0.10.0",
       "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
-      "dev": true
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
     },
     "plist": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
       "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
-      "dev": true,
       "requires": {
         "base64-js": "1.1.2",
         "xmlbuilder": "8.2.2",
@@ -55,7 +49,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
       "integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
-      "dev": true,
       "requires": {
         "bplist-creator": "0.0.7",
         "bplist-parser": "0.1.1",
@@ -65,20 +58,17 @@
     "stream-buffers": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
-      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
-      "dev": true
+      "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
     },
     "uuid": {
       "version": "3.0.1",
       "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-      "dev": true
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
     },
     "xcode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xcode/-/xcode-1.0.0.tgz",
       "integrity": "sha1-4fWxRDJF3tOMGAeW3xoQ/e2ghOw=",
-      "dev": true,
       "requires": {
         "pegjs": "^0.10.0",
         "simple-plist": "^0.2.1",
@@ -88,14 +78,12 @@
     "xmlbuilder": {
       "version": "8.2.2",
       "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
-      "dev": true
+      "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
     },
     "xmldom": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-      "dev": true
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       "version": ">=3.0.0"
     }
   ],
-  "devDependencies": {
+  "dependencies": {
     "xcode": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     }
   ],
   "dependencies": {
+    "elementtree": "0.1.7",
     "xcode": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
       "name": "cordova",
       "version": ">=3.0.0"
     }
-  ]
+  ],
+  "devDependencies": {
+    "xcode": "^1.0.0"
+  }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -69,6 +69,8 @@
     <source-file src="src/ios/HealthKit.m"/>
 
     <framework src="HealthKit.framework" weak="true" />
+
+    <hook type="after_plugin_install" src="scripts/after-plugin-install.js" />
   </platform>
 
 </plugin>

--- a/scripts/after-plugin-install.js
+++ b/scripts/after-plugin-install.js
@@ -7,10 +7,10 @@ module.exports = function (ctx) {
   }
 
   try {
-    var fs = ctx.requireCordovaModule('fs'),
-      path = ctx.requireCordovaModule('path'),
+    var fs = require('fs'),
+      path = require('path'),
       configXMLPath = path.join(ctx.opts.projectRoot, 'config.xml'),
-      et = ctx.requireCordovaModule('elementtree'),
+      et = require('elementtree'),
       xcode = require('xcode'),
       usageDescription;
 

--- a/scripts/after-plugin-install.js
+++ b/scripts/after-plugin-install.js
@@ -1,36 +1,62 @@
 module.exports = function (ctx) {
-  if (ctx.cmdLine.indexOf('USE_CLINICAL_RECORDS') < 0) {
-    console.log('USE_CLINICAL_RECORDS was not provided');
+  if (ctx.cmdLine.indexOf('CLINICAL_READ_PERMISSION') < 0) {
+    console.log('CLINICAL_READ_PERMISSION was not provided');
     return;
   }
 
-  var fs = ctx.requireCordovaModule('fs'),
-    path = ctx.requireCordovaModule('path'),
-    deferral = ctx.requireCordovaModule('q').defer(),
-    configXMLPath = path.join(ctx.opts.projectRoot, 'config.xml'),
-    et = ctx.requireCordovaModule('elementtree'),
-    xcode = require('xcode');
+  try {
+    var fs = ctx.requireCordovaModule('fs'),
+      path = ctx.requireCordovaModule('path'),
+      deferral = ctx.requireCordovaModule('q').defer(),
+      configXMLPath = path.join(ctx.opts.projectRoot, 'config.xml'),
+      et = ctx.requireCordovaModule('elementtree'),
+      xcode = require('xcode');
 
-  var configData = fs.readFileSync(configXMLPath).toString();
-  var etree = et.parse(configData);
-  var appName = etree.findtext('./name');
-  var srcPath = path.join(ctx.opts.projectRoot, 'plugins/com.telerik.plugins.healthkit/src/ios');
-  var projPath = path.join(ctx.opts.projectRoot, 'platforms/ios', appName + '.xcodeproj/project.pbxproj');
-  var xcodeProj = xcode.project(projPath);
 
-  xcodeProj.parse(function(err) {
-    if (err) {
-      console.log('xcode proj parse error, err: ', err);
-      return deferral.reject(err);
-    }
+    var usageDescription = ctx.cmdLine.split('CLINICAL_READ_PERMISSION=')[1].split('--')[0].trim();
 
-    xcodeProj.addHeaderFile(path.join(srcPath, 'HealthKitClinicalRecords.h'));
-    xcodeProj.addSourceFile(path.join(srcPath, 'HealthKitClinicalRecords.m'));
+    console.log('*** Installing HealthKitClinicalRecords ***');
+    console.log('CLINICAL_READ_PERMISSION = ', usageDescription);
 
-    fs.writeFileSync(projPath, xcodeProj.writeSync());
+    var configData = fs.readFileSync(configXMLPath).toString();
+    var etree = et.parse(configData);
+    var appName = etree.findtext('./name');
+    var srcPath = path.join(ctx.opts.projectRoot, 'plugins/com.telerik.plugins.healthkit/src/ios');
+    var projPath = path.join(ctx.opts.projectRoot, 'platforms/ios', appName + '.xcodeproj/project.pbxproj');
+    var xcodeProj = xcode.project(projPath);
 
-    return deferral.resolve();
-  });
+    xcodeProj.parse(function (err) {
+      if (err) {
+        console.log('xcode proj parse error, err: ', err);
+        return deferral.reject(err);
+      }
+
+      xcodeProj.addHeaderFile(path.join(srcPath, 'HealthKitClinicalRecords.h'));
+      xcodeProj.addSourceFile(path.join(srcPath, 'HealthKitClinicalRecords.m'));
+
+      fs.writeFileSync(projPath, xcodeProj.writeSync());
+
+      // add CLINICAL_READ_PERMISSION text to config.xml
+      var tagPlatform = etree.findall('./platform[@name="ios"]');
+      if (tagPlatform.length > 0) {
+        var tagEditConfig = et.Element('edit-config', { file: '*-Info.plist', mode: 'merge', target: 'NSHealthClinicalHealthRecordsShareUsageDescription' });
+        var tagString = et.Element('string');
+        tagString.text = usageDescription;
+        tagEditConfig.append(tagString);
+        tagPlatform[0].append(tagEditConfig);
+
+        configData = etree.write({ 'indent': 4 });
+        fs.writeFileSync(configXMLPath, configData);
+      }
+
+      console.log('*** DONE Installing HealthKitClinicalRecords ***');
+
+      return deferral.resolve();
+    });
+  } catch(e) {
+    console.log('after-plugin-install error, e: ', JSON.stringify(e, null, 2));
+    deferral.reject(e);
+  }
 
   return deferral.promise;
 };

--- a/scripts/after-plugin-install.js
+++ b/scripts/after-plugin-install.js
@@ -39,7 +39,7 @@ module.exports = function (ctx) {
       // add CLINICAL_READ_PERMISSION text to config.xml
       var tagPlatform = etree.findall('./platform[@name="ios"]');
       if (tagPlatform.length > 0) {
-        var tagEditConfig = et.Element('edit-config', { file: '*-Info.plist', mode: 'merge', target: 'NSHealthClinicalHealthRecordsShareUsageDescription' });
+        var tagEditConfig = et.Element('config-file', { target: '*-Info.plist', parent: 'NSHealthClinicalHealthRecordsShareUsageDescription' });
         var tagString = et.Element('string');
         tagString.text = usageDescription;
         tagEditConfig.append(tagString);

--- a/scripts/after-plugin-install.js
+++ b/scripts/after-plugin-install.js
@@ -1,0 +1,36 @@
+module.exports = function (ctx) {
+  if (ctx.cmdLine.indexOf('USE_CLINICAL_RECORDS') < 0) {
+    console.log('USE_CLINICAL_RECORDS was not provided');
+    return;
+  }
+
+  var fs = ctx.requireCordovaModule('fs'),
+    path = ctx.requireCordovaModule('path'),
+    deferral = ctx.requireCordovaModule('q').defer(),
+    configXMLPath = path.join(ctx.opts.projectRoot, 'config.xml'),
+    et = ctx.requireCordovaModule('elementtree'),
+    xcode = require('xcode');
+
+  var configData = fs.readFileSync(configXMLPath).toString();
+  var etree = et.parse(configData);
+  var appName = etree.findtext('./name');
+  var srcPath = path.join(ctx.opts.projectRoot, 'plugins/com.telerik.plugins.healthkit/src/ios');
+  var projPath = path.join(ctx.opts.projectRoot, 'platforms/ios', appName + '.xcodeproj/project.pbxproj');
+  var xcodeProj = xcode.project(projPath);
+
+  xcodeProj.parse(function(err) {
+    if (err) {
+      console.log('xcode proj parse error, err: ', err);
+      return deferral.reject(err);
+    }
+
+    xcodeProj.addHeaderFile(path.join(srcPath, 'HealthKitClinicalRecords.h'));
+    xcodeProj.addSourceFile(path.join(srcPath, 'HealthKitClinicalRecords.m'));
+
+    fs.writeFileSync(projPath, xcodeProj.writeSync());
+
+    return deferral.resolve();
+  });
+
+  return deferral.promise;
+};

--- a/src/ios/HealthKit.h
+++ b/src/ios/HealthKit.h
@@ -123,6 +123,20 @@
 - (void) querySampleTypeAggregated:(CDVInvokedUrlCommand*)command;
 
 /**
+ * Search for a particular FHIR record
+ *
+ * @param command *CDVInvokedUrlCommand
+ */
+- (void)queryForClinicalRecordsFromSource:(CDVInvokedUrlCommand *)command;
+
+/**
+ * Search for a specific FHIR resource type
+ *
+ * @param command *CDVInvokedUrlCommand
+ */
+- (void)queryForClinicalRecordsWithFHIRResourceType:(CDVInvokedUrlCommand *)command;
+
+/**
  * Save quantity sample data
  *
  * @param command *CDVInvokedUrlCommand

--- a/src/ios/HealthKit.h
+++ b/src/ios/HealthKit.h
@@ -1,6 +1,25 @@
 #import "Cordova/CDV.h"
 #import <HealthKit/HealthKit.h>
 
+#pragma mark Property Type Constants
+static NSString *const HKPluginError = @"HKPluginError";
+static NSString *const HKPluginKeyReadTypes = @"readTypes";
+static NSString *const HKPluginKeyWriteTypes = @"writeTypes";
+static NSString *const HKPluginKeyType = @"type";
+static NSString *const HKPluginKeyStartDate = @"startDate";
+static NSString *const HKPluginKeyEndDate = @"endDate";
+static NSString *const HKPluginKeySampleType = @"sampleType";
+static NSString *const HKPluginKeyAggregation = @"aggregation";
+static NSString *const HKPluginKeyUnit = @"unit";
+static NSString *const HKPluginKeyAmount = @"amount";
+static NSString *const HKPluginKeyValue = @"value";
+static NSString *const HKPluginKeyCorrelationType = @"correlationType";
+static NSString *const HKPluginKeyObjects = @"samples";
+static NSString *const HKPluginKeySourceName = @"sourceName";
+static NSString *const HKPluginKeySourceBundleId = @"sourceBundleId";
+static NSString *const HKPluginKeyMetadata = @"metadata";
+static NSString *const HKPluginKeyUUID = @"UUID";
+
 @interface HealthKit :CDVPlugin
 
 /**
@@ -123,18 +142,25 @@
 - (void) querySampleTypeAggregated:(CDVInvokedUrlCommand*)command;
 
 /**
+ * Query a specified clinical sample type
+ *
+ * @param command *CDVInvokedUrlCommand
+ */
+- (void) queryClinicalSampleType:(CDVInvokedUrlCommand *)command;
+
+/**
  * Search for a particular FHIR record
  *
  * @param command *CDVInvokedUrlCommand
  */
-- (void)queryForClinicalRecordsFromSource:(CDVInvokedUrlCommand *)command;
+- (void) queryForClinicalRecordsFromSource:(CDVInvokedUrlCommand *)command;
 
 /**
  * Search for a specific FHIR resource type
  *
  * @param command *CDVInvokedUrlCommand
  */
-- (void)queryForClinicalRecordsWithFHIRResourceType:(CDVInvokedUrlCommand *)command;
+- (void) queryForClinicalRecordsWithFHIRResourceType:(CDVInvokedUrlCommand *)command;
 
 /**
  * Save quantity sample data
@@ -164,4 +190,45 @@
  */
 - (void) deleteSamples:(CDVInvokedUrlCommand*)command;
 
+@end
+
+// Public Interface extension category
+@interface HealthKit ()
++ (HKHealthStore *)sharedHealthStore;
+@end
+
+// Internal interface
+@interface HealthKit (Internal)
+- (void)checkAuthStatusWithCallbackId:(NSString *)callbackId
+                              forType:(HKObjectType *)type
+                        andCompletion:(void (^)(CDVPluginResult *result, NSString *innerCallbackId))completion;
+@end
+
+
+// Internal interface helper methods
+@interface HealthKit (InternalHelpers)
++ (NSString *)stringFromDate:(NSDate *)date;
+
++ (HKUnit *)getUnit:(NSString *)type expected:(NSString *)expected;
+
++ (HKObjectType *)getHKObjectType:(NSString *)elem;
+
++ (HKQuantityType *)getHKQuantityType:(NSString *)elem;
+
++ (HKSampleType *)getHKSampleType:(NSString *)elem;
+
+- (HKQuantitySample *)loadHKQuantitySampleFromInputDictionary:(NSDictionary *)inputDictionary error:(NSError **)error;
+
+- (HKCorrelation *)loadHKCorrelationFromInputDictionary:(NSDictionary *)inputDictionary error:(NSError **)error;
+
++ (HKQuantitySample *)getHKQuantitySampleWithStartDate:(NSDate *)startDate endDate:(NSDate *)endDate sampleTypeString:(NSString *)sampleTypeString unitTypeString:(NSString *)unitTypeString value:(double)value metadata:(NSDictionary *)metadata error:(NSError **)error;
+
+- (HKCorrelation *)getHKCorrelationWithStartDate:(NSDate *)startDate endDate:(NSDate *)endDate correlationTypeString:(NSString *)correlationTypeString objects:(NSSet *)objects metadata:(NSDictionary *)metadata error:(NSError **)error;
+
++ (void)triggerErrorCallbackWithMessage: (NSString *) message command: (CDVInvokedUrlCommand *) command delegate: (id<CDVCommandDelegate>) delegate;
+@end
+
+// NSDictionary check if there is a value for a required key and populate an error if not present
+@interface NSDictionary (RequiredKey)
+- (BOOL)hasAllRequiredKeys:(NSArray<NSString *> *)keys error:(NSError **)error;
 @end

--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -1,7 +1,10 @@
 #import "HealthKit.h"
 #import "HKHealthStore+AAPLExtensions.h"
 #import "WorkoutActivityConversion.h"
+
+#ifdef HealthKitClinicalRecords_h
 #import "HealthKitClinicalRecords.h"
+#endif
 
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCNotLocalizedStringInspection"
@@ -1480,7 +1483,9 @@
  * @param command *CDVInvokedUrlCommand
  */
 - (void)queryClinicalSampleType:(CDVInvokedUrlCommand *)command {
+  #ifdef HealthKitClinicalRecords_h
   [HealthKitClinicalRecords queryClinicalSampleType:command delegate:self.commandDelegate];
+  #endif
 }
 
 /**
@@ -1489,7 +1494,9 @@
  * @param command *CDVInvokedUrlCommand
  */
 - (void)queryForClinicalRecordsFromSource:(CDVInvokedUrlCommand *)command {
+  #ifdef HealthKitClinicalRecords_h
   [HealthKitClinicalRecords queryForClinicalRecordsFromSource:command delegate:self.commandDelegate];
+  #endif
 }
 
 /**
@@ -1498,7 +1505,9 @@
  * @param command *CDVInvokedUrlCommand
  */
 - (void)queryForClinicalRecordsWithFHIRResourceType:(CDVInvokedUrlCommand *)command {
+  #ifdef HealthKitClinicalRecords_h
   [HealthKitClinicalRecords queryForClinicalRecordsWithFHIRResourceType:command delegate:self.commandDelegate];
+  #endif
 }
 
 /**

--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -1,76 +1,13 @@
 #import "HealthKit.h"
 #import "HKHealthStore+AAPLExtensions.h"
 #import "WorkoutActivityConversion.h"
+#import "HealthKitClinicalRecords.h"
 
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCNotLocalizedStringInspection"
 #define HKPLUGIN_DEBUG
 
-#pragma mark Property Type Constants
-static NSString *const HKPluginError = @"HKPluginError";
-static NSString *const HKPluginKeyReadTypes = @"readTypes";
-static NSString *const HKPluginKeyWriteTypes = @"writeTypes";
-static NSString *const HKPluginKeyType = @"type";
-static NSString *const HKPluginKeyStartDate = @"startDate";
-static NSString *const HKPluginKeyEndDate = @"endDate";
-static NSString *const HKPluginKeySampleType = @"sampleType";
-static NSString *const HKPluginKeyAggregation = @"aggregation";
-static NSString *const HKPluginKeyUnit = @"unit";
-static NSString *const HKPluginKeyAmount = @"amount";
-static NSString *const HKPluginKeyValue = @"value";
-static NSString *const HKPluginKeyCorrelationType = @"correlationType";
-static NSString *const HKPluginKeyObjects = @"samples";
-static NSString *const HKPluginKeySourceName = @"sourceName";
-static NSString *const HKPluginKeySourceBundleId = @"sourceBundleId";
-static NSString *const HKPluginKeyMetadata = @"metadata";
-static NSString *const HKPluginKeyUUID = @"UUID";
-
 #pragma mark Categories
-
-// NSDictionary check if there is a value for a required key and populate an error if not present
-@interface NSDictionary (RequiredKey)
-- (BOOL)hasAllRequiredKeys:(NSArray<NSString *> *)keys error:(NSError **)error;
-@end
-
-// Public Interface extension category
-@interface HealthKit ()
-+ (HKHealthStore *)sharedHealthStore;
-@end
-
-// Internal interface
-@interface HealthKit (Internal)
-- (void)checkAuthStatusWithCallbackId:(NSString *)callbackId
-                              forType:(HKObjectType *)type
-                        andCompletion:(void (^)(CDVPluginResult *result, NSString *innerCallbackId))completion;
-@end
-
-
-// Internal interface helper methods
-@interface HealthKit (InternalHelpers)
-+ (NSString *)stringFromDate:(NSDate *)date;
-
-+ (HKUnit *)getUnit:(NSString *)type expected:(NSString *)expected;
-
-+ (HKObjectType *)getHKObjectType:(NSString *)elem;
-
-+ (HKQuantityType *)getHKQuantityType:(NSString *)elem;
-
-+ (HKSampleType *)getHKSampleType:(NSString *)elem;
-
-+ (HKFHIRResourceType)getFHIRResourceType:(NSString *)elem API_AVAILABLE(ios(12.0));
-
-- (HKQuantitySample *)loadHKQuantitySampleFromInputDictionary:(NSDictionary *)inputDictionary error:(NSError **)error;
-
-- (HKCorrelation *)loadHKCorrelationFromInputDictionary:(NSDictionary *)inputDictionary error:(NSError **)error;
-
-+ (HKQuantitySample *)getHKQuantitySampleWithStartDate:(NSDate *)startDate endDate:(NSDate *)endDate sampleTypeString:(NSString *)sampleTypeString unitTypeString:(NSString *)unitTypeString value:(double)value metadata:(NSDictionary *)metadata error:(NSError **)error;
-
-- (HKCorrelation *)getHKCorrelationWithStartDate:(NSDate *)startDate endDate:(NSDate *)endDate correlationTypeString:(NSString *)correlationTypeString objects:(NSSet *)objects metadata:(NSDictionary *)metadata error:(NSError **)error;
-
-+ (void)triggerErrorCallbackWithMessage: (NSString *) message command: (CDVInvokedUrlCommand *) command delegate: (id<CDVCommandDelegate>) delegate;
-
-+ (void)returnClinicalResultsFromQuery: (NSArray *)results  command: (CDVInvokedUrlCommand *) command delegate: (id<CDVCommandDelegate>) delegate;
-@end
 
 /**
  * Implementation of internal interface
@@ -188,7 +125,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
     if (type != nil) {
         return type;
     }
-
+  
     if (@available(iOS 12.0, *)) {
       type = [HKObjectType clinicalTypeForIdentifier:elem];
       if (type != nil) {
@@ -199,34 +136,6 @@ static NSString *const HKPluginKeyUUID = @"UUID";
     // @TODO | The fall through here is inefficient.
     // @TODO | It needs to be refactored so the same HK method isnt called twice
     return [HealthKit getHKSampleType:elem];
-}
-
-/**
- * Get a FHIR Resource Type constant by name
- *
- * @param elem  *NSString
- * @return      *HKFHIRResourceType
- */
-+ (HKFHIRResourceType)getFHIRResourceType:(NSString *)elem  API_AVAILABLE(ios(12.0)) {
-  if (@available(iOS 12.0, *)) {
-    HKFHIRResourceType type = nil;
-    NSDictionary *fhirResourceTypeMap = @{
-                                          @"HKFHIRResourceTypeAllergyIntolerance": HKFHIRResourceTypeAllergyIntolerance,
-                                          @"HKFHIRResourceTypeCondition": HKFHIRResourceTypeCondition,
-                                          @"HKFHIRResourceTypeImmunization": HKFHIRResourceTypeImmunization,
-                                          @"HKFHIRResourceTypeMedicationDispense": HKFHIRResourceTypeMedicationDispense,
-                                          @"HKFHIRResourceTypeMedicationOrder": HKFHIRResourceTypeMedicationOrder,
-                                          @"HKFHIRResourceTypeMedicationStatement": HKFHIRResourceTypeMedicationStatement,
-                                          @"HKFHIRResourceTypeObservation": HKFHIRResourceTypeObservation,
-                                          @"HKFHIRResourceTypeProcedure": HKFHIRResourceTypeProcedure
-                                          };
-    
-    type = fhirResourceTypeMap[elem];
-    
-    return type;
-  }
-  
-  return nil;
 }
 
 /**
@@ -276,7 +185,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
             // Fallback on earlier versions
         }
     }
-
+  
     if (@available(iOS 12.0, *)) {
       type = [HKObjectType clinicalTypeForIdentifier:elem];
       if (type != nil) {
@@ -465,67 +374,6 @@ static NSString *const HKPluginKeyUUID = @"UUID";
         CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];
         [delegate sendPluginResult:result callbackId:command.callbackId];
     }
-}
-
-/**
- * Generic output for clinical results
- *
- * @param message   *NSString
- * @param command   *CDVInvokedUrlCommand
- * @param delegate  id<CDVCommandDelegate>
- */
-
-+ (void)returnClinicalResultsFromQuery: (NSArray *)results  command: (CDVInvokedUrlCommand *) command delegate: (id<CDVCommandDelegate>) delegate {
-  @autoreleasepool {
-    if (@available(iOS 12.0, *)) {
-      NSMutableArray *finalResults = [[NSMutableArray alloc] initWithCapacity:results.count];
-      
-      for (HKSample *sample in results) {
-        
-        NSDate *startSample = sample.startDate;
-        NSDate *endSample = sample.endDate;
-        NSMutableDictionary *entry = [NSMutableDictionary dictionary];
-        
-        // common indices
-        entry[HKPluginKeyStartDate] =[HealthKit stringFromDate:startSample];
-        entry[HKPluginKeyEndDate] = [HealthKit stringFromDate:endSample];
-        entry[HKPluginKeyUUID] = sample.UUID.UUIDString;
-        
-        entry[HKPluginKeySourceName] = sample.sourceRevision.source.name;
-        entry[HKPluginKeySourceBundleId] = sample.sourceRevision.source.bundleIdentifier;
-        
-        if (sample.metadata == nil || ![NSJSONSerialization isValidJSONObject:sample.metadata]) {
-          entry[HKPluginKeyMetadata] = @{};
-        } else {
-          entry[HKPluginKeyMetadata] = sample.metadata;
-        }
-        
-        if ([sample isKindOfClass:[HKClinicalRecord class]]) {
-          HKClinicalRecord *clinicalRecord = (HKClinicalRecord *) sample;
-          NSError *err = nil;
-          NSDictionary *fhirData = [NSJSONSerialization JSONObjectWithData:clinicalRecord.FHIRResource.data options:NSJSONReadingMutableContainers error:&err];
-          
-          if (err != nil) {
-            [HealthKit triggerErrorCallbackWithMessage:err.localizedDescription command:command delegate:delegate];
-            return;
-          } else {
-            NSDictionary *fhirResource = @{
-                                           @"identifier": clinicalRecord.FHIRResource.identifier,
-                                           @"sourceURL": clinicalRecord.FHIRResource.sourceURL.absoluteString,
-                                           @"displayName": clinicalRecord.displayName,
-                                           @"data": fhirData
-                                           };
-            entry[@"FHIRResource"] = fhirResource;
-          }
-        }
-        
-        [finalResults addObject:entry];
-      }
-      
-      CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:finalResults];
-      [delegate sendPluginResult:result callbackId:command.callbackId];
-    }
-  }
 }
 
 @end
@@ -1457,33 +1305,6 @@ static NSString *const HKPluginKeyUUID = @"UUID";
                                                                               HKWorkout *wsample = (HKWorkout *) sample;
                                                                               [entry setValue:@(wsample.duration) forKey:@"duration"];
 
-                                                                          } else {
-
-                                                                            if (@available(iOS 12.0, *)) {
-                                                                            
-                                                                                if ([sample isKindOfClass:[HKClinicalRecord class]]) {
-                                                                                    HKClinicalRecord *clinicalRecord = (HKClinicalRecord *) sample;
-                                                                                    NSError *err = nil;
-                                                                                    NSDictionary *fhirData = [NSJSONSerialization JSONObjectWithData:clinicalRecord.FHIRResource.data options:NSJSONReadingMutableContainers error:&err];
-                                                                                    
-                                                                                    if (err != nil) {
-                                                                                        dispatch_sync(dispatch_get_main_queue(), ^{
-                                                                                            [HealthKit triggerErrorCallbackWithMessage:err.localizedDescription command:command delegate:bSelf.commandDelegate];
-                                                                                        });
-                                                                                        return;
-                                                                                    } else {
-                                                                                        NSDictionary *fhirResource = @{
-                                                                                                        @"identifier": clinicalRecord.FHIRResource.identifier,
-                                                                                                        @"sourceURL": clinicalRecord.FHIRResource.sourceURL.absoluteString,
-                                                                                                        @"displayName": clinicalRecord.displayName,
-                                                                                                        @"data": fhirData
-                                                                                                    };
-                                                                                        entry[@"FHIRResource"] = fhirResource;
-                                                                                    }
-                                                                                }
-                                                                            
-                                                                            }
-
                                                                           }
 
                                                                           [finalResults addObject:entry];
@@ -1654,78 +1475,21 @@ static NSString *const HKPluginKeyUUID = @"UUID";
 }
 
 /**
+ * Query a specified clinical sample type
+ *
+ * @param command *CDVInvokedUrlCommand
+ */
+- (void)queryClinicalSampleType:(CDVInvokedUrlCommand *)command {
+  [HealthKitClinicalRecords queryClinicalSampleType:command delegate:self.commandDelegate];
+}
+
+/**
  * Search for a particular FHIR record
  *
  * @param command *CDVInvokedUrlCommand
  */
 - (void)queryForClinicalRecordsFromSource:(CDVInvokedUrlCommand *)command {
-  if (@available(iOS 12.0, *)) {
-    NSDictionary *args = command.arguments[0];
-    
-    NSString *sampleTypeString = args[HKPluginKeySampleType];
-    HKSampleType *sampleType = [HealthKit getHKSampleType:sampleTypeString];
-    NSString *fhirResourceTypeString = args[@"fhirResourceType"];
-    HKFHIRResourceType fhirResourceType = [HealthKit getFHIRResourceType:fhirResourceTypeString];
-    NSString *sourceName = [args valueForKeyPath:@"source.name"];
-    NSString *bundleIdentifier = [args valueForKeyPath:@"source.bundleIdentifier"];
-    NSString *identifier = args[@"identifier"];
-    
-    if (sampleType == nil) {
-      [HealthKit triggerErrorCallbackWithMessage:@"sampleType was invalid" command:command delegate:self.commandDelegate];
-      return;
-    }
-    
-    if (fhirResourceType == nil) {
-      [HealthKit triggerErrorCallbackWithMessage:@"fhirResourceType was invalid" command:command delegate:self.commandDelegate];
-    }
-    
-    HKSourceQuery *sourceQuery = [[HKSourceQuery alloc] initWithSampleType:sampleType
-                                                           samplePredicate:nil
-                                                         completionHandler:^(HKSourceQuery * _Nonnull query, NSSet<HKSource *> * _Nullable sources, NSError * _Nullable error) {
-                                                           if (error) {
-                                                             [HealthKit triggerErrorCallbackWithMessage:error.localizedDescription command:command delegate:self.commandDelegate];
-                                                             return;
-                                                           }
-                                                           
-                                                           HKSource *fromSource = nil;
-                                                           
-                                                           for (HKSource *source in sources) {
-                                                             if ([source.name isEqualToString:sourceName] && [source.bundleIdentifier isEqualToString:bundleIdentifier]) {
-                                                               fromSource = source;
-                                                               break;
-                                                             }
-                                                           }
-                                                           
-                                                           if (fromSource == nil) {
-                                                             [HealthKit triggerErrorCallbackWithMessage:@"Unable to obtain source by name and bundleIdentifier" command:command delegate:self.commandDelegate];
-                                                             return;
-                                                           }
-                                                           
-                                                           NSPredicate *predicate = [HKQuery predicateForClinicalRecordsFromSource:fromSource FHIRResourceType:fhirResourceType identifier:identifier];
-                                                           
-                                                           HKSampleQuery *sampleQuery = [[HKSampleQuery alloc] initWithSampleType:sampleType
-                                                                                                                  predicate:predicate
-                                                                                                                      limit:HKObjectQueryNoLimit
-                                                                                                            sortDescriptors:nil
-                                                                                                             resultsHandler:^(HKSampleQuery * _Nonnull query, NSArray<__kindof HKSample *> * _Nullable results, NSError * _Nullable error) {
-                                                                                                               if (error != nil) {
-                                                                                                                 dispatch_sync(dispatch_get_main_queue(), ^{
-                                                                                                                   [HealthKit triggerErrorCallbackWithMessage:error.localizedDescription command:command delegate:self.commandDelegate];
-                                                                                                                 });
-                                                                                                               } else {
-                                                                                                                 dispatch_sync(dispatch_get_main_queue(), ^{
-                                                                                                                   [HealthKit returnClinicalResultsFromQuery:results command:command delegate:self.commandDelegate];
-                                                                                                                 });
-                                                                                                               }
-                                                                                                             }];
-                                                           
-                                                           [[HealthKit sharedHealthStore] executeQuery:sampleQuery];
-                                                         }];
-    
-    [[HealthKit sharedHealthStore] executeQuery:sourceQuery];
-  } else {
-    [HealthKit triggerErrorCallbackWithMessage:@"queryForClinicalRecordsFromSource requires ios 12 or higher" command:command delegate:self.commandDelegate];
-  }
+  [HealthKitClinicalRecords queryForClinicalRecordsFromSource:command delegate:self.commandDelegate];
 }
 
 /**
@@ -1734,45 +1498,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
  * @param command *CDVInvokedUrlCommand
  */
 - (void)queryForClinicalRecordsWithFHIRResourceType:(CDVInvokedUrlCommand *)command {
-  if (@available(iOS 12.0, *)) {
-    NSDictionary *args = command.arguments[0];
-    
-    NSString *sampleTypeString = args[HKPluginKeySampleType];
-    HKSampleType *sampleType = [HealthKit getHKSampleType:sampleTypeString];
-    NSString *fhirResourceTypeString = args[@"fhirResourceType"];
-    HKFHIRResourceType fhirResourceType = [HealthKit getFHIRResourceType:fhirResourceTypeString];
-    
-    if (sampleType == nil) {
-      [HealthKit triggerErrorCallbackWithMessage:@"sampleType was invalid" command:command delegate:self.commandDelegate];
-      return;
-    }
-    
-    if (fhirResourceType == nil) {
-      [HealthKit triggerErrorCallbackWithMessage:@"fhirResourceType was invalid" command:command delegate:self.commandDelegate];
-    }
-    
-    NSPredicate *predicate = [HKQuery predicateForClinicalRecordsWithFHIRResourceType:fhirResourceType];
-    
-    HKSampleQuery *query = [[HKSampleQuery alloc] initWithSampleType:sampleType
-                                                           predicate:predicate
-                                                               limit:HKObjectQueryNoLimit
-                                                     sortDescriptors:nil
-                                                      resultsHandler:^(HKSampleQuery * _Nonnull query, NSArray<__kindof HKSample *> * _Nullable results, NSError * _Nullable error) {
-                                                        if (error != nil) {
-                                                          dispatch_sync(dispatch_get_main_queue(), ^{
-                                                            [HealthKit triggerErrorCallbackWithMessage:error.localizedDescription command:command delegate:self.commandDelegate];
-                                                          });
-                                                        } else {
-                                                          dispatch_sync(dispatch_get_main_queue(), ^{
-                                                            [HealthKit returnClinicalResultsFromQuery:results command:command delegate:self.commandDelegate];
-                                                          });
-                                                        }
-                                                      }];
-    
-    [[HealthKit sharedHealthStore] executeQuery:query];
-  } else {
-    [HealthKit triggerErrorCallbackWithMessage:@"queryForClinicalRecordsWithFHIRResourceType requires ios 12 or higher" command:command delegate:self.commandDelegate];
-  }
+  [HealthKitClinicalRecords queryForClinicalRecordsWithFHIRResourceType:command delegate:self.commandDelegate];
 }
 
 /**

--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -2,8 +2,9 @@
 #import "HKHealthStore+AAPLExtensions.h"
 #import "WorkoutActivityConversion.h"
 
-#ifdef HealthKitClinicalRecords_h
+#if __has_include("HealthKitClinicalRecords.h")
 #import "HealthKitClinicalRecords.h"
+#define HKPLUGIN_CLINICAL_RECORDS
 #endif
 
 #pragma clang diagnostic push
@@ -1483,7 +1484,7 @@
  * @param command *CDVInvokedUrlCommand
  */
 - (void)queryClinicalSampleType:(CDVInvokedUrlCommand *)command {
-  #ifdef HealthKitClinicalRecords_h
+  #ifdef HKPLUGIN_CLINICAL_RECORDS
   [HealthKitClinicalRecords queryClinicalSampleType:command delegate:self.commandDelegate];
   #endif
 }
@@ -1494,7 +1495,7 @@
  * @param command *CDVInvokedUrlCommand
  */
 - (void)queryForClinicalRecordsFromSource:(CDVInvokedUrlCommand *)command {
-  #ifdef HealthKitClinicalRecords_h
+  #ifdef HKPLUGIN_CLINICAL_RECORDS
   [HealthKitClinicalRecords queryForClinicalRecordsFromSource:command delegate:self.commandDelegate];
   #endif
 }
@@ -1505,7 +1506,7 @@
  * @param command *CDVInvokedUrlCommand
  */
 - (void)queryForClinicalRecordsWithFHIRResourceType:(CDVInvokedUrlCommand *)command {
-  #ifdef HealthKitClinicalRecords_h
+  #ifdef HKPLUGIN_CLINICAL_RECORDS
   [HealthKitClinicalRecords queryForClinicalRecordsWithFHIRResourceType:command delegate:self.commandDelegate];
   #endif
 }

--- a/src/ios/HealthKitClinicalRecords.h
+++ b/src/ios/HealthKitClinicalRecords.h
@@ -1,0 +1,35 @@
+//
+//  HealthKitClinicalRecords.h
+//
+//  Created by Ross Martin
+//
+
+
+@interface HealthKitClinicalRecords : NSObject
+
+/**
+ * Query a specified clinical sample type
+ *
+ * @param command *CDVInvokedUrlCommand
+ * @param delegate (id<CDVCommandDelegate>)
+ */
++ (void)queryClinicalSampleType:(CDVInvokedUrlCommand *)command delegate: (id<CDVCommandDelegate>) delegate;
+
+/**
+ * Search for a particular FHIR record
+ *
+ * @param command *CDVInvokedUrlCommand
+ * @param delegate (id<CDVCommandDelegate>)
+ */
++ (void)queryForClinicalRecordsFromSource:(CDVInvokedUrlCommand *)command delegate: (id<CDVCommandDelegate>) delegate;
+
+/**
+ * Search for a specific FHIR resource type
+ *
+ * @param command *CDVInvokedUrlCommand
+ * @param delegate (id<CDVCommandDelegate>)
+ */
++ (void)queryForClinicalRecordsWithFHIRResourceType:(CDVInvokedUrlCommand *)command delegate: (id<CDVCommandDelegate>) delegate;
+
+@end
+

--- a/src/ios/HealthKitClinicalRecords.h
+++ b/src/ios/HealthKitClinicalRecords.h
@@ -4,6 +4,11 @@
 //  Created by Ross Martin
 //
 
+#ifndef HealthKitClinicalRecords_h
+#define HealthKitClinicalRecords_h
+
+#endif /* HealthKitClinicalRecords_h */
+
 
 @interface HealthKitClinicalRecords : NSObject
 

--- a/src/ios/HealthKitClinicalRecords.h
+++ b/src/ios/HealthKitClinicalRecords.h
@@ -4,11 +4,6 @@
 //  Created by Ross Martin
 //
 
-#ifndef HealthKitClinicalRecords_h
-#define HealthKitClinicalRecords_h
-
-#endif /* HealthKitClinicalRecords_h */
-
 
 @interface HealthKitClinicalRecords : NSObject
 

--- a/src/ios/HealthKitClinicalRecords.m
+++ b/src/ios/HealthKitClinicalRecords.m
@@ -1,0 +1,284 @@
+//
+//  HealthKitClinicalRecords.m
+//
+//  Created by Ross Martin
+//
+
+#import "HealthKit.h"
+#import "HealthKitClinicalRecords.h"
+
+
+@implementation HealthKitClinicalRecords
+
+/**
+ * Query a specified clinical sample type
+ *
+ * @param command *CDVInvokedUrlCommand
+ * @param delegate (id<CDVCommandDelegate>)
+ */
++ (void)queryClinicalSampleType:(CDVInvokedUrlCommand *)command delegate: (id<CDVCommandDelegate>) delegate {
+  if (@available(iOS 12.0, *)) {
+    NSDictionary *args = command.arguments[0];
+    NSDate *startDate = [NSDate dateWithTimeIntervalSince1970:[args[HKPluginKeyStartDate] longValue]];
+    NSDate *endDate = [NSDate dateWithTimeIntervalSince1970:[args[HKPluginKeyEndDate] longValue]];
+    NSString *sampleTypeString = args[HKPluginKeySampleType];
+    NSUInteger limit = ((args[@"limit"] != nil) ? [args[@"limit"] unsignedIntegerValue] : 100);
+    BOOL ascending = (args[@"ascending"] != nil && [args[@"ascending"] boolValue]);
+    
+    HKSampleType *type = [HKObjectType clinicalTypeForIdentifier:sampleTypeString];
+    if (type == nil) {
+      [HealthKit triggerErrorCallbackWithMessage:@"sampleType was invalid" command:command delegate:delegate];
+      return;
+    }
+    // TODO check that unit is compatible with sampleType if sample type of HKQuantityType
+    NSPredicate *predicate = [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionStrictStartDate];
+    
+    NSSet *requestTypes = [NSSet setWithObjects:type, nil];
+    [[HealthKit sharedHealthStore] requestAuthorizationToShareTypes:nil readTypes:requestTypes completion:^(BOOL success, NSError *error) {
+      if (success) {
+        NSString *endKey = HKSampleSortIdentifierEndDate;
+        NSSortDescriptor *endDateSort = [NSSortDescriptor sortDescriptorWithKey:endKey ascending:ascending];
+        HKSampleQuery *query = [[HKSampleQuery alloc] initWithSampleType:type
+                                             predicate:predicate
+                                             limit:limit
+                                             sortDescriptors:@[endDateSort]
+                                             resultsHandler:^(HKSampleQuery *sampleQuery,
+                                             NSArray *results,
+                                             NSError *innerError) {
+                                              if (innerError != nil) {
+                                                dispatch_sync(dispatch_get_main_queue(), ^{
+                                                  [HealthKit triggerErrorCallbackWithMessage:innerError.localizedDescription command:command delegate:delegate];
+                                                });
+                                              } else {
+                                                dispatch_sync(dispatch_get_main_queue(), ^{
+                                                  [self returnClinicalResultsFromQuery:results command:command delegate:delegate];
+                                                });
+                                              }
+                                           }];
+        
+        [[HealthKit sharedHealthStore] executeQuery:query];
+      } else {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+          [HealthKit triggerErrorCallbackWithMessage:error.localizedDescription command:command delegate:delegate];
+        });
+      }
+    }];
+  } else {
+    [HealthKit triggerErrorCallbackWithMessage:@"queryClinicalSampleType requires ios 12 or higher" command:command delegate:delegate];
+  }
+}
+
+/**
+ * Search for a particular FHIR record
+ *
+ * @param command *CDVInvokedUrlCommand
+ * @param delegate (id<CDVCommandDelegate>)
+ */
++ (void)queryForClinicalRecordsFromSource:(CDVInvokedUrlCommand *) command delegate: (id<CDVCommandDelegate>) delegate {
+  if (@available(iOS 12.0, *)) {
+    NSDictionary *args = command.arguments[0];
+    
+    NSString *sampleTypeString = args[HKPluginKeySampleType];
+    HKSampleType *sampleType = [HKObjectType clinicalTypeForIdentifier:sampleTypeString];
+    NSString *fhirResourceTypeString = args[@"fhirResourceType"];
+    HKFHIRResourceType fhirResourceType = [self getFHIRResourceType:fhirResourceTypeString];
+    NSString *sourceName = [args valueForKeyPath:@"source.name"];
+    NSString *bundleIdentifier = [args valueForKeyPath:@"source.bundleIdentifier"];
+    NSString *identifier = args[@"identifier"];
+    
+    if (sampleType == nil) {
+      [HealthKit triggerErrorCallbackWithMessage:@"sampleType was invalid" command:command delegate:delegate];
+      return;
+    }
+    
+    if (fhirResourceType == nil) {
+      [HealthKit triggerErrorCallbackWithMessage:@"fhirResourceType was invalid" command:command delegate:delegate];
+    }
+    
+    HKSourceQuery *sourceQuery = [[HKSourceQuery alloc] initWithSampleType:sampleType
+                                               samplePredicate:nil
+                                               completionHandler:^(HKSourceQuery * _Nonnull query, NSSet<HKSource *> * _Nullable sources, NSError * _Nullable error) {
+                                                 if (error) {
+                                                   [HealthKit triggerErrorCallbackWithMessage:error.localizedDescription command:command delegate:delegate];
+                                                   return;
+                                                 }
+                                                 
+                                                 HKSource *fromSource = nil;
+                                                 
+                                                 for (HKSource *source in sources) {
+                                                   if ([source.name isEqualToString:sourceName] && [source.bundleIdentifier isEqualToString:bundleIdentifier]) {
+                                                     fromSource = source;
+                                                     break;
+                                                   }
+                                                 }
+                                                 
+                                                 if (fromSource == nil) {
+                                                   [HealthKit triggerErrorCallbackWithMessage:@"Unable to obtain source by name and bundleIdentifier" command:command delegate:delegate];
+                                                   return;
+                                                 }
+                                                 
+                                                 NSPredicate *predicate = [HKQuery predicateForClinicalRecordsFromSource:fromSource FHIRResourceType:fhirResourceType identifier:identifier];
+                                                 
+                                                 HKSampleQuery *sampleQuery = [[HKSampleQuery alloc] initWithSampleType:sampleType
+                                                    predicate:predicate
+                                                    limit:HKObjectQueryNoLimit
+                                                    sortDescriptors:nil
+                                                    resultsHandler:^(HKSampleQuery * _Nonnull query, NSArray<__kindof HKSample *> * _Nullable results, NSError * _Nullable error) {
+                                                     if (error != nil) {
+                                                       dispatch_sync(dispatch_get_main_queue(), ^{
+                                                         [HealthKit triggerErrorCallbackWithMessage:error.localizedDescription command:command delegate:delegate];
+                                                       });
+                                                     } else {
+                                                       dispatch_sync(dispatch_get_main_queue(), ^{
+                                                         [self returnClinicalResultsFromQuery:results command:command delegate:delegate];
+                                                       });
+                                                     }
+                                                 }];
+                                                 
+                                                 [[HealthKit sharedHealthStore] executeQuery:sampleQuery];
+                                               }];
+    
+    [[HealthKit sharedHealthStore] executeQuery:sourceQuery];
+  } else {
+    [HealthKit triggerErrorCallbackWithMessage:@"queryForClinicalRecordsFromSource requires ios 12 or higher" command:command delegate:delegate];
+  }
+}
+
+/**
+ * Search for a specific FHIR resource type
+ *
+ * @param command *CDVInvokedUrlCommand
+ * @param delegate (id<CDVCommandDelegate>)
+ */
++ (void)queryForClinicalRecordsWithFHIRResourceType:(CDVInvokedUrlCommand *)command delegate: (id<CDVCommandDelegate>) delegate {
+  if (@available(iOS 12.0, *)) {
+    NSDictionary *args = command.arguments[0];
+    
+    NSString *sampleTypeString = args[HKPluginKeySampleType];
+    HKSampleType *sampleType = [HKObjectType clinicalTypeForIdentifier:sampleTypeString];
+    NSString *fhirResourceTypeString = args[@"fhirResourceType"];
+    HKFHIRResourceType fhirResourceType = [self getFHIRResourceType:fhirResourceTypeString];
+    
+    if (sampleType == nil) {
+      [HealthKit triggerErrorCallbackWithMessage:@"sampleType was invalid" command:command delegate:delegate];
+      return;
+    }
+    
+    if (fhirResourceType == nil) {
+      [HealthKit triggerErrorCallbackWithMessage:@"fhirResourceType was invalid" command:command delegate:delegate];
+    }
+    
+    NSPredicate *predicate = [HKQuery predicateForClinicalRecordsWithFHIRResourceType:fhirResourceType];
+    
+    HKSampleQuery *query = [[HKSampleQuery alloc] initWithSampleType:sampleType
+                                       predicate:predicate
+                                       limit:HKObjectQueryNoLimit
+                                       sortDescriptors:nil
+                                       resultsHandler:^(HKSampleQuery * _Nonnull query, NSArray<__kindof HKSample *> * _Nullable results, NSError * _Nullable error) {
+                                          if (error != nil) {
+                                            dispatch_sync(dispatch_get_main_queue(), ^{
+                                              [HealthKit triggerErrorCallbackWithMessage:error.localizedDescription command:command delegate:delegate];
+                                            });
+                                          } else {
+                                            dispatch_sync(dispatch_get_main_queue(), ^{
+                                              [self returnClinicalResultsFromQuery:results command:command delegate:delegate];
+                                            });
+                                          }
+                                        }];
+
+    [[HealthKit sharedHealthStore] executeQuery:query];
+  } else {
+    [HealthKit triggerErrorCallbackWithMessage:@"queryForClinicalRecordsWithFHIRResourceType requires ios 12 or higher" command:command delegate:delegate];
+  }
+}
+
+/**
+ * Get a FHIR Resource Type constant by name
+ *
+ * @param elem  *NSString
+ * @return      *HKFHIRResourceType
+ */
++ (HKFHIRResourceType)getFHIRResourceType:(NSString *)elem  API_AVAILABLE(ios(12.0)) {
+  if (@available(iOS 12.0, *)) {
+    HKFHIRResourceType type = nil;
+    NSDictionary *fhirResourceTypeMap = @{
+                                      @"HKFHIRResourceTypeAllergyIntolerance": HKFHIRResourceTypeAllergyIntolerance,
+                                      @"HKFHIRResourceTypeCondition": HKFHIRResourceTypeCondition,
+                                      @"HKFHIRResourceTypeImmunization": HKFHIRResourceTypeImmunization,
+                                      @"HKFHIRResourceTypeMedicationDispense": HKFHIRResourceTypeMedicationDispense,
+                                      @"HKFHIRResourceTypeMedicationOrder": HKFHIRResourceTypeMedicationOrder,
+                                      @"HKFHIRResourceTypeMedicationStatement": HKFHIRResourceTypeMedicationStatement,
+                                      @"HKFHIRResourceTypeObservation": HKFHIRResourceTypeObservation,
+                                      @"HKFHIRResourceTypeProcedure": HKFHIRResourceTypeProcedure
+                                    };
+    
+    type = fhirResourceTypeMap[elem];
+    
+    return type;
+  }
+  
+  return nil;
+}
+
+/**
+ * Generic output for clinical results
+ *
+ * @param message   *NSString
+ * @param command   *CDVInvokedUrlCommand
+ * @param delegate  id<CDVCommandDelegate>
+ */
+
++ (void)returnClinicalResultsFromQuery: (NSArray *)results  command: (CDVInvokedUrlCommand *) command delegate: (id<CDVCommandDelegate>) delegate {
+  @autoreleasepool {
+    if (@available(iOS 12.0, *)) {
+      NSMutableArray *finalResults = [[NSMutableArray alloc] initWithCapacity:results.count];
+      
+      for (HKSample *sample in results) {
+        
+        NSDate *startSample = sample.startDate;
+        NSDate *endSample = sample.endDate;
+        NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+        
+        // common indices
+        entry[HKPluginKeyStartDate] =[HealthKit stringFromDate:startSample];
+        entry[HKPluginKeyEndDate] = [HealthKit stringFromDate:endSample];
+        entry[HKPluginKeyUUID] = sample.UUID.UUIDString;
+        
+        entry[HKPluginKeySourceName] = sample.sourceRevision.source.name;
+        entry[HKPluginKeySourceBundleId] = sample.sourceRevision.source.bundleIdentifier;
+        
+        if (sample.metadata == nil || ![NSJSONSerialization isValidJSONObject:sample.metadata]) {
+          entry[HKPluginKeyMetadata] = @{};
+        } else {
+          entry[HKPluginKeyMetadata] = sample.metadata;
+        }
+        
+        if ([sample isKindOfClass:[HKClinicalRecord class]]) {
+          HKClinicalRecord *clinicalRecord = (HKClinicalRecord *) sample;
+          NSError *err = nil;
+          NSDictionary *fhirData = [NSJSONSerialization JSONObjectWithData:clinicalRecord.FHIRResource.data options:NSJSONReadingMutableContainers error:&err];
+          
+          if (err != nil) {
+            [HealthKit triggerErrorCallbackWithMessage:err.localizedDescription command:command delegate:delegate];
+            return;
+          } else {
+            NSDictionary *fhirResource = @{
+                                       @"identifier": clinicalRecord.FHIRResource.identifier,
+                                       @"sourceURL": clinicalRecord.FHIRResource.sourceURL.absoluteString,
+                                       @"displayName": clinicalRecord.displayName,
+                                       @"data": fhirData
+                                     };
+            entry[@"FHIRResource"] = fhirResource;
+          }
+        }
+        
+        [finalResults addObject:entry];
+      }
+      
+      CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:finalResults];
+      [delegate sendPluginResult:result callbackId:command.callbackId];
+    }
+  }
+}
+  
+@end

--- a/www/HealthKit.js
+++ b/www/HealthKit.js
@@ -117,6 +117,8 @@ define('deleteSamples', {required: 'sampleType'}, hasValidDates);
 define('queryCorrelationType', {required: 'correlationType'}, hasValidDates);
 define('saveQuantitySample', {required: 'sampleType'}, hasValidDates);
 
+define('queryForClinicalRecordsWithFHIRResourceType', {required: ['sampleType', 'fhirResourceType']});
+
 define('saveCorrelation', {required: ['correlationType', 'samples']}, function(options) {
   hasValidDates(options);
   options.objects = options.samples.map(hasValidDates);

--- a/www/HealthKit.js
+++ b/www/HealthKit.js
@@ -117,6 +117,7 @@ define('deleteSamples', {required: 'sampleType'}, hasValidDates);
 define('queryCorrelationType', {required: 'correlationType'}, hasValidDates);
 define('saveQuantitySample', {required: 'sampleType'}, hasValidDates);
 
+define('queryForClinicalRecordsFromSource', {required: ['sampleType', 'fhirResourceType', 'identifier', 'source']});
 define('queryForClinicalRecordsWithFHIRResourceType', {required: ['sampleType', 'fhirResourceType']});
 
 define('saveCorrelation', {required: ['correlationType', 'samples']}, function(options) {

--- a/www/HealthKit.js
+++ b/www/HealthKit.js
@@ -117,6 +117,7 @@ define('deleteSamples', {required: 'sampleType'}, hasValidDates);
 define('queryCorrelationType', {required: 'correlationType'}, hasValidDates);
 define('saveQuantitySample', {required: 'sampleType'}, hasValidDates);
 
+define('queryClinicalSampleType', {required: 'sampleType'}, hasValidDates);
 define('queryForClinicalRecordsFromSource', {required: ['sampleType', 'fhirResourceType', 'identifier', 'source']});
 define('queryForClinicalRecordsWithFHIRResourceType', {required: ['sampleType', 'fhirResourceType']});
 


### PR DESCRIPTION
This PR has a few things, most notably including -

- adds `queryClinicalSampleType`, `queryForClinicalRecordsFromSource`, and `queryForClinicalRecordsWithFHIRResourceType`.
- resolves #103.
- the readme was updated with info about reading clinical data.
- the demo was updated with usage and info on the new functions.
- the deprecated API calls on `source` were fixed.